### PR TITLE
build: add CircleCI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ workflows:
     jobs:
       - test
       - release:
+          context: mongodb
           filters:
             branches:
               only: master


### PR DESCRIPTION
Adds the [`context`](https://circleci.com/docs/2.0/configuration-reference/#context) directive to the CircleCI configuration file.